### PR TITLE
Add secure spark example

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Downstreamer Test for Apache HBase
+Copyright 2013 - 2016 various contributors:
+
+* Michael Stack
+* Nick Dimiduk
+* Elliott Clark
+* Sean Busbey

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,8 @@ Copyright 2013 - 2016 various contributors:
 * Nick Dimiduk
 * Elliott Clark
 * Sean Busbey
+
+
+Contains software created at the Apache Software Foundation, which is covered by the Apache Software License version 2.0.
+
+* src/main/java/org/hbase/downstreamer/spark/JavaNetworkWordCountStoreInHBase.java from Apache Spark (c) 2014 the Apache Software Foundation

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ your ZooKeeper quorum (defaults to localhost).
 
 The application should print out many entries from an hbase internal table and then exit without error.
 
+building against specific HBase versions
+===============================
+
 To build against an older version of HBase 1.y, specify hbase.version property on the maven
 command line. Similarly, you can use hadoop.version to specify a different release of Hadoop 2.
 For example, in this example we build against HBase 1.0.1 and Hadoop 2.7.0 (an unstable release of
@@ -56,7 +59,10 @@ pass -U to maven building):
         -Dhbase.staging.repository='https://repository.apache.org/content/repositories/orgapachehbase-1001' \
         clean package
 
-Finally, if you wish to verify client-server wire compatibility between HBase & Hadoop versions you can
+testing client-server compatibility with a standalone client
+============================================================
+
+If you wish to verify client-server wire compatibility between HBase & Hadoop versions you can
 build a standalone jar using the 'client-standalone' profile. This profile can be combined with any of the
 above options for choosing an HBase and Hadoop version, but you must always specify the HBase profile
 you want.
@@ -75,4 +81,64 @@ access to HBase client configuration files and the location of your zookeeper qu
     0
 
 The application should print out many entries from an hbase internal table and then exit without error.
+
+spark streaming test application
+================================
+
+This project includes a Spark Streaming application with renewed tokens for long-running against a kerberos-enabled hbase cluster.
+
+Prerequisites:
+    
+  - hbase client configs deployed to all yarn worker nodes (in /etc/hbase/conf)
+  - have a keytab and associated principal with run access for yarn and write access to hbase (replace 'auser@EXAMPLE.COM' with a real principal for your KDC)
+
+Build as described above. Optionally choose Scala and Spark versions appropriate for your distribution via `scala.version` and `spark.version`. The defaults are the equivalent to
+    
+        $ mvn -Dscala.version=2.10 -Dspark.version=1.5.0
+    
+Run a netcat instance generating data (below examples presume this host is named _netcat.running.host.example.com_
+    
+        $ yes | nc -lk 1772
+
+Create needed test table in hbase and grant access to 'auser' (presumes hbase user has stored kerberos tickets)
+
+        $ sudo -u hbase hbase shell
+        hbase(main):001:0> create 'counts', 'word_counts'
+        0 row(s) in 0.6740 seconds
+
+        => Hbase::Table - counts
+        hbase(main):002:0>  grant 'auser', 'RW', 'counts'
+        0 row(s) in 0.7300 seconds
+
+        hbase(main):003:0>
+
+Test run with writes to hbase on the cluster (no need to kinit, presuming default hbase, hadoop, and slf4j versions):
+
+        $ spark-submit --master yarn --deploy-mode cluster --keytab auser.keytab --principal 'auser@EXAMPLE.COM' --class org.hbase.downstreamer.spark.JavaNetworkWordCountStoreInHBase --packages org.slf4j:slf4j-api:1.7.5 hbase-downstreamer-1.0-SNAPSHOT-1.1.0_2.6.0.jar netcat.running.host.example.com 1772 2>spark.log | tee spark.out
+
+Alternative, you can use the standalone client jar. In addition to relying on the HBase client jars you package, this will let you skip including the slf4j-api jars:
+
+        $ spark-submit --master yarn --deploy-mode cluster --keytab auser.keytab --principal 'auser@EXAMPLE.COM' --class org.hbase.downstreamer.spark.JavaNetworkWordCountStoreInHBase hbase-downstreamer-1.0-SNAPSHOT-1.1.0_2.6.0-standalone.jar netcat.running.host.example.com 1772 2>spark.log | tee spark.out
+
+Verify results in hbase (presumes you have stored kerberos tickets)
+
+        $ echo "count \"counts\"; scan \"counts\", {REVERSED => true, LIMIT => 10}" | hbase shell --noninteractive 2>/dev/null
+
+        Current count: 1000, row: 1458924355000 ms
+        1944 row(s) in 0.5740 seconds
+
+        ROW  COLUMN+CELL
+         1458925431000 ms column=word_counts:y, timestamp=1458925432081, value=\x00\x14@\xFC
+         1458925430000 ms column=word_counts:y, timestamp=1458925430537, value=\x00$\xE1\xF2
+         1458925429000 ms column=word_counts:y, timestamp=1458925429676, value=\x00\x13\xFC\xA2
+         1458925428000 ms column=word_counts:y, timestamp=1458925428673, value=\x00\x11\xCC\x9C
+         1458925427000 ms column=word_counts:y, timestamp=1458925428189, value=\x00\x07\xCF\xE5
+         1458925426000 ms column=word_counts:y, timestamp=1458925427861, value=\x00/\x18\x0C
+         1458925425000 ms column=word_counts:y, timestamp=1458925425436, value=\x00\x0A\xC4\x0D
+         1458925424000 ms column=word_counts:y, timestamp=1458925424717, value=\x00\x1E}%
+         1458925423000 ms column=word_counts:y, timestamp=1458925423821, value=\x00\x1B&\x1D
+         1458925422000 ms column=word_counts:y, timestamp=1458925422677, value=\x00\x06jt
+        10 row(s) in 0.0400 seconds
+
+        nil
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
   <url>https://github.com/saintstack/hbase-downstreamer</url>
   <properties>
     <hbase.staging.repository>https://repository.apache.org/content/repositories/orgapachehbase-076/</hbase.staging.repository>
+    <scala.version>2.10</scala.version>
+    <slf4j.version>1.7.5</slf4j.version>
+    <spark.version>1.5.0</spark.version>
   </properties>
   <dependencies>
     <!--START OF TEST SCOPE-->
@@ -56,10 +59,24 @@
     </dependency>
     <!--END OF TEST SCOPE-->
 
+    <!-- General client dependencies, to be included in standalone jar -->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
       <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Spark Streaming dependencies, should not be included in standalone jar -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,17 @@
     </profile>
   </profiles>
   <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE</include>
+          <include>NOTICE</include>
+          <include>README.md</include>
+        </includes>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/src/main/java/org/hbase/downstreamer/spark/JavaNetworkWordCountStoreInHBase.java
+++ b/src/main/java/org/hbase/downstreamer/spark/JavaNetworkWordCountStoreInHBase.java
@@ -1,0 +1,269 @@
+/*
+ * Changes Copyright 2016 hbase-downstreamer contributor(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Original code covered under:
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * derived from:
+ * https://raw.githubusercontent.com/apache/spark/v1.5.0/examples/src/main/java/org/apache/spark/examples/streaming/JavaNetworkWordCount.java
+ *
+ */
+
+package org.hbase.downstreamer.spark;
+
+import scala.Tuple2;
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.hbase.ClusterStatus;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.StorageLevels;
+import org.apache.spark.deploy.SparkHadoopUtil;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.Iterator;
+
+/**
+ * Counts words in UTF8 encoded, '\n' delimited text received from the network every second. Then
+ * stores the counts in HBase using a table layout of:
+ *
+ *  RowID          |     CF          |   CQ     | value
+ * time in millis  |  "word_counts"  |  <word>  |  <count for period>
+ *
+ * Works on secure clusters for an indefinite period via keytab login. NOTE: copies the given
+ * keytab to the working directory of executors.
+ *
+ * Usage: JavaNetworkWordCountStoreInHBase <hostname> <port>
+ * <hostname> and <port> describe the TCP server that Spark Streaming would connect to receive data.
+ *
+ * To run this on your local machine, you need to first run a Netcat server
+ *    `$ nc -lk 9999`
+ * and then run the example
+ *    `$ bin/run-example org.apache.spark.examples.streaming.JavaNetworkWordCount localhost 9999`
+ */
+public final class JavaNetworkWordCountStoreInHBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JavaNetworkWordCountStoreInHBase.class);
+
+  /**
+   * Write each word:count pair into hbase, in a row for the given time period.
+   */
+  public static final class StoreCountsToHBase implements VoidFunction<Iterator<Tuple2<String,Integer>>> {
+
+    private static final TableName COUNTS = TableName.valueOf("counts");
+    private static final byte[] WORD_COUNTS = Bytes.toBytes("word_counts");
+
+    private static final ConcurrentHashMap<Tuple2<String,String>, Tuple2<UserGroupInformation, Connection>>
+        connections = new ConcurrentHashMap<Tuple2<String,String>, Tuple2<UserGroupInformation, Connection>>();
+
+    private byte[] ROW_ID;
+    /** (principal, keytab) */
+    private final Tuple2<String, String> auth;
+
+    public StoreCountsToHBase(final SparkConf sparkConf) {
+      auth = new Tuple2<String,String>(sparkConf.get("spark.yarn.principal"), sparkConf.get("spark.yarn.keytab"));
+    }
+
+    public void setTime(Time time) {
+      ROW_ID = Bytes.toBytes(time.toString());
+    }
+
+    /**
+     * Rely on a map of (principal,keytab) => connection to ensure we only keep around one per
+     * Classloader.
+     */
+    private static Tuple2<UserGroupInformation, Connection> ensureConnection(final Tuple2<String, String> auth)
+        throws IOException, InterruptedException {
+      Tuple2<UserGroupInformation, Connection> result = connections.get(auth);
+      if (result == null) {
+        LOG.info("Setting up HBase connection.");
+        try {
+          final SparkHadoopUtil util = SparkHadoopUtil.get();
+          final Configuration conf = HBaseConfiguration.create(util.newConfiguration(new SparkConf()));
+          // This work-around for getting hbase client configs requires that you deploy an HBase GATEWAY
+          // role on each node that can run a spark executor.
+          final File clientConfigs = new File("/etc/hbase/conf");
+          for (File siteConfig : clientConfigs.listFiles()) {
+            if (siteConfig.getName().endsWith(".xml")) {
+              LOG.debug("Adding config resource: {}", siteConfig);
+              conf.addResource(siteConfig.toURI().toURL());
+            }
+          }
+          UserGroupInformation ugi = null;
+          Connection connection = null;
+          synchronized(UserGroupInformation.class) {
+            LOG.debug("setting UGI conf");
+            UserGroupInformation.setConfiguration(conf);
+            LOG.debug("Ability to read keytab '{}' : {}", auth._2(), (new File(auth._2())).canRead());
+            LOG.debug("logging in via UGI and keytab.");
+            ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(auth._1(), auth._2());
+            LOG.info("finished login attempt via UGI and keytab. security set? {}", ugi.isSecurityEnabled());
+          }
+          connection = ugi.doAs(new PrivilegedExceptionAction<Connection>() {
+            @Override
+            public Connection run() throws IOException {
+              return ConnectionFactory.createConnection(conf);
+            }
+          });
+          // Do something with the connection now, to ensure we have valid credentials.
+          final Admin admin = connection.getAdmin();
+          try {
+            final ClusterStatus status = admin.getClusterStatus();
+            LOG.info("connection successful: {}", status);
+            final Tuple2<UserGroupInformation, Connection> proposed = new Tuple2<UserGroupInformation, Connection>(ugi, connection);
+            final Tuple2<UserGroupInformation, Connection> prior = connections.putIfAbsent(auth, proposed);
+            if (prior == null) {
+              // our proposed connection is valid.
+              result = proposed;
+            } else {
+              // parallel instantiation beat us to completion
+              LOG.warn("Discarding extra connection. No need to be concerned, unless this message happens dozens of times.");
+              result = prior;
+              connection.close();
+            }
+          } finally {
+            admin.close();
+          }
+        } catch (IOException exception) {
+          LOG.error("Failed to connect to hbase. rethrowing; application should fail.", exception);
+          throw exception;
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public void call(Iterator<Tuple2<String, Integer>> iterator) throws IOException, InterruptedException {
+      try {
+        Tuple2<UserGroupInformation, Connection> hbase = ensureConnection(auth);
+        // This presumes we can complete our Put calculation before the TGT expires.
+        // At worst after this check we will have 20% of the ticket window left; for 24hr tickets that means
+        // just under 5 hours.
+        hbase._1().checkTGTAndReloginFromKeytab();
+        final Table table = hbase._2().getTable(COUNTS);
+        Put put = new Put(ROW_ID);
+        while (iterator.hasNext()) {
+          final Tuple2<String, Integer> wordCount = iterator.next();
+          put.addColumn(WORD_COUNTS, Bytes.toBytes(wordCount._1), Bytes.toBytes(wordCount._2));
+        }
+        if (!put.isEmpty()) {
+          LOG.debug("Putting " + put.size() + " cells.");
+          table.put(put);
+        }
+      } catch (IOException exception) {
+        LOG.error("Failed to put cells. rethrowing; application should fail.", exception);
+        throw exception;
+      }
+    }
+  }
+
+  private static final Pattern SPACE = Pattern.compile(" ");
+
+  public static void main(String[] args) {
+    if (args.length < 2) {
+      System.err.println("Usage: JavaNetworkWordCountStoreInHBase <hostname> <port>");
+      System.exit(1);
+    }
+
+    // Create the context with a 1 second batch size
+    SparkConf sparkConf = new SparkConf().setAppName("JavaNetworkWordCountStoreInHBase");
+    JavaStreamingContext ssc = new JavaStreamingContext(sparkConf, Durations.seconds(1));
+
+    // Copy the keytab to our executors
+    ssc.sparkContext().addFile(sparkConf.get("spark.yarn.keytab"));
+
+    // Create a JavaReceiverInputDStream on target ip:port and count the
+    // words in input stream of \n delimited text (eg. generated by 'nc')
+    // Note that no duplication in storage level only for running locally.
+    // Replication necessary in distributed scenario for fault tolerance.
+    JavaReceiverInputDStream<String> lines = ssc.socketTextStream(
+            args[0], Integer.parseInt(args[1]), StorageLevels.MEMORY_AND_DISK_SER);
+    JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+      @Override
+      public Iterable<String> call(String x) {
+        return Lists.newArrayList(SPACE.split(x));
+      }
+    });
+    JavaPairDStream<String, Integer> wordCounts = words.mapToPair(
+      new PairFunction<String, String, Integer>() {
+        @Override
+        public Tuple2<String, Integer> call(String s) {
+          return new Tuple2<String, Integer>(s, 1);
+        }
+      }).reduceByKey(new Function2<Integer, Integer, Integer>() {
+        @Override
+        public Integer call(Integer i1, Integer i2) {
+          return i1 + i2;
+        }
+      });
+
+    final StoreCountsToHBase store = new StoreCountsToHBase(sparkConf);
+
+    wordCounts.foreachRDD(new Function2<JavaPairRDD<String, Integer>, Time, Void>() {
+      @Override
+      public Void call(JavaPairRDD<String, Integer> rdd, Time time) throws IOException {
+        store.setTime(time);
+        rdd.foreachPartition(store);
+        return null;
+      }
+    });
+
+    ssc.start();
+    ssc.awaitTermination();
+  }
+}


### PR DESCRIPTION
- Add example Apache Spark Streaming app for writing to HBase based on Spark's example "JavaNetworkWordCount"
- works with secure HBase cluster using kerberos details provided on command line for YARN/HDFS
- relies on keytab login on executors, since Spark doesn't have a generic delegation token renewal process yet
- include walkthrough in README
- update NOTICE for the Spark derived code