### PR TITLE
update hbase-2 module for upstream 2.0.0 release.

### DIFF
--- a/hbase-2/pom.xml
+++ b/hbase-2/pom.xml
@@ -12,7 +12,7 @@
   <name>Downstream HBase 2.y API</name>
   <properties>
     <hbase.version>${hbase.2.version}</hbase.version>
-    <hadoop.version>2.6.1</hadoop.version>
+    <hadoop.version>2.7.1</hadoop.version>
     <!-- These should match default from HBase 2 release -->
     <scala.version>2.10.4</scala.version>
     <scala.binary>2.10</scala.binary>

--- a/hbase-2/src/main/java/org/hbase/downstreamer/GetMetaContent.java
+++ b/hbase-2/src/main/java/org/hbase/downstreamer/GetMetaContent.java
@@ -21,7 +21,7 @@ public class GetMetaContent {
     Configuration configuration = HBaseConfiguration.create();
     if (args.length > 0) configuration.set(HConstants.ZOOKEEPER_QUORUM, args[0]);
     try (final Connection connection = ConnectionFactory.createConnection(configuration);
-         final Table t = connection.getTable(TableName.valueOf(HConstants.META_TABLE_NAME));
+         final Table t = connection.getTable(TableName.META_TABLE_NAME);
          final ResultScanner scanner = t.getScanner(new Scan())) {
       for (Result r = null; (r = scanner.next()) != null;) {
         System.out.println(r);

--- a/hbase-2/src/test/java/org/hbase/downstreamer/TestHBaseMiniCluster.java
+++ b/hbase-2/src/test/java/org/hbase/downstreamer/TestHBaseMiniCluster.java
@@ -1,6 +1,8 @@
 package org.hbase.downstreamer;
 
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
 import org.junit.Test;
@@ -11,7 +13,10 @@ import org.junit.Test;
 public class TestHBaseMiniCluster {
   @Test
   public void testSpinUpMiniHBaseCluster() throws Exception {
-    HBaseTestingUtility htu = new HBaseTestingUtility();
+    Configuration config = HBaseConfiguration.create();
+    // work around HBASE-20544
+    config.setBoolean("hbase.localcluster.assign.random.ports", true);
+    HBaseTestingUtility htu = new HBaseTestingUtility(config);
     try {
       htu.startMiniCluster();
       htu.getMetaTableRows();

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <hbase.98.version>0.98.24</hbase.98.version>
     <hbase.1.version>1.2.6</hbase.1.version>
-    <hbase.2.version>2.0.0-alpha2</hbase.2.version>
+    <hbase.2.version>2.0.0</hbase.2.version>
   </properties>
   <modules>
     <module>hbase-0.98</module>


### PR DESCRIPTION
this is still a WIP. I'd rather not update the hadoop version, but the test failed with a CNFE. something from hadoop-hdfs that ought to be present.